### PR TITLE
Add aarch64-darwin to pkgsFor in flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ or if you use smfh as the linker
 systemctl start hjem-activate@userName.service
 ```
 
+> [!TIP]
+> If running on darwin system with `smfh` linker (default), use
+> ```
+> launchctl start org.hjem.activate
+> ```
+
 ### How does it work exactly?
 hjem impure module simply reads information hjem uses to plant files in place. 
 This information is converted into a shell script

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     ...
   } @ inputs: let
     inherit (nixpkgs.lib) getAttrs mapAttrs nixosSystem;
-    pkgsFor = getAttrs ["x86_64-linux" "aarch64-linux"] nixpkgs.legacyPackages;
+    pkgsFor = getAttrs ["x86_64-linux" "aarch64-linux" "aarch64-darwin"] nixpkgs.legacyPackages;
     eachSystem = fn: mapAttrs fn pkgsFor;
     specialArgs = {inherit inputs self;};
   in {


### PR DESCRIPTION
This PR adds support for hjem-impure to nix-darwin.
This change is nothing more than adding the "aarch64-darwin" system and check if it works (it does).
I can't test for x86_64-darwin so I didn't added to the list of systems, but it should be working too.

It was tested locally and working (at least for the hjem-impure command, since systemd is not used on darwin I didn't checked what would be the equivalent of `systemd-tmpfiles --user --create` or `systemctl start hjem-activate@userName.service` and if these works at all.)

I would like to know what would be the next step to get this merged (adding tests, etc.), I am new to nix packaging.

Close #5 