### PR TITLE
Improve relinking feature implementation

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,8 +5,8 @@
   ...
 }: let
   inherit (lib) mkEnableOption mkIf mkOption literalExpression mkRenamedOptionModule;
-  inherit (lib) map pipe filter hasPrefix removePrefix concatStringsSep substring escapeRegex elemAt head;
-  inherit (lib) assertMsg optional optionalString pathExists foldl attrValues isList removeSuffix match;
+  inherit (lib) map pipe filter hasPrefix removePrefix concatStringsSep substring escapeRegex elemAt head match;
+  inherit (lib) assertMsg optional optionalString pathExists foldl attrValues isList removeSuffix stringLength;
   inherit (lib.types) str listOf enum path nullOr raw;
 
   cfg = config.impure;
@@ -80,11 +80,12 @@
       '');
   };
 
-  relPathRegex = "(${escapeRegex (removeSuffix "/" cfg.dotsDirImpure)}|/nix/store/[^/]+)(/.+)"; # Regex matches [(dotsDirImpure or "/nix/store/<HASH>-...") "/relPath"]
+  storeLength = (stringLength builtins.storeDir) + 33; # "/nix/store" (10) + "/" (1) + "<HASH>" (32) = len + 33
+  relPathRegex = "(${escapeRegex (removeSuffix "/" cfg.dotsDirImpure)}|${escapeRegex builtins.storeDir}/[^/]+)(.*)"; # Regex matches [(dotsDirImpure or "/nix/store/<HASH>-...") "/relPath"]
   symlinkFiles = pipe cfg.parseAttrs [
     (filter (x:
       if cfg.dotsDir == null # Uses "-relink=" method if dotsDir is unset, symlinkFiles is already guarded by cfg.dotsDirImpure != ""
-      then (substring 43 8 "${x.source}") == "-relink=" # /nix/store/ (11) + <HASH> (32) = 43, "-relink=" (8)
+      then (substring storeLength 8 "${x.source}") == "-relink=" # "/nix/store" (10) + "/" (1) + "<HASH>" (32) = storeLength + 33, "-relink=" (8)
       else cfg.dotsDir != null && hasPrefix "${cfg.dotsDir}" "${x.source}"))
     # ensures that paths are valid. Throws an error if they aren't. "-relink=" method checks on the original passthru.path instead of its build store path to avoid IFD
     (filter (x: assertMsg (pathExists (if cfg.dotsDir == null then x.source.path else x.source)) "hjem-impure: the path ${x.source} DOES NOT EXIST"))
@@ -100,7 +101,7 @@
     (filter (x:
       ! (
         if cfg.dotsDir == null
-        then cfg.dotsDirImpure != "" && ((substring 43 8 "${x.source}") == "-relink=")
+        then cfg.dotsDirImpure != "" && ((substring storeLength 8 "${x.source}") == "-relink=")
         else cfg.dotsDir != null && hasPrefix "${cfg.dotsDir}" "${x.source}"
       )))
     (map (x: "replace ${x.target}"))

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,9 +5,9 @@
   ...
 }: let
   inherit (lib) mkEnableOption mkIf mkOption literalExpression mkRenamedOptionModule;
-  inherit (lib) map pipe filter hasPrefix removePrefix concatStringsSep;
-  inherit (lib) assertMsg optional optionalString pathExists foldl attrValues;
-  inherit (lib.types) str listOf enum path nullOr;
+  inherit (lib) map pipe filter hasPrefix removePrefix concatStringsSep substring escapeRegex elemAt head;
+  inherit (lib) assertMsg optional optionalString pathExists foldl attrValues isList removeSuffix match;
+  inherit (lib.types) str listOf enum path nullOr raw;
 
   cfg = config.impure;
   hjemFileAttrList = [
@@ -69,7 +69,7 @@
 
         echo 1 > "$IMPURE_ACTIVE_FILE" || echo "[INFO] Unable to write to $IMPURE_ACTIVE_FILE"
       ''
-      + (optionalString (cfg.dotsDir != null) ''
+      + (optionalString (cfg.dotsDirImpure != "") ''
         echo ""
         echo "Redirecting symlinks to dotsDirImpure"
         ${
@@ -80,23 +80,48 @@
       '');
   };
 
+  relPathRegex = "(${escapeRegex (removeSuffix "/" cfg.dotsDirImpure)}|/nix/store/[^/]+)(/.+)"; # Regex matches [(dotsDirImpure or "/nix/store/<HASH>-...") "/relPath"]
   symlinkFiles = pipe cfg.parseAttrs [
-    (filter (x: cfg.dotsDir != null && hasPrefix "${cfg.dotsDir}" "${x.source}"))
-    # ensures that paths are valid. Throws an error if they aren't
-    (filter (x: assertMsg (pathExists x.source) "hjem-impure: the path ${x.source} DOES NOT EXIST"))
-    (map (x: "symlink ${cfg.dotsDirImpure}${removePrefix "${cfg.dotsDir}" "${x.source}"} ${x.target}"))
+    (filter (x:
+      if cfg.dotsDir == null # Uses "-relink=" method if dotsDir is unset, symlinkFiles is already guarded by cfg.dotsDirImpure != ""
+      then (substring 43 8 "${x.source}") == "-relink=" # /nix/store/ (11) + <HASH> (32) = 43, "-relink=" (8)
+      else cfg.dotsDir != null && hasPrefix "${cfg.dotsDir}" "${x.source}"))
+    # ensures that paths are valid. Throws an error if they aren't. "-relink=" method checks on the original passthru.path instead of its build store path to avoid IFD
+    (filter (x: assertMsg (pathExists (if cfg.dotsDir == null then x.source.path else x.source)) "hjem-impure: the path ${x.source} DOES NOT EXIST"))
+    (map (x: "symlink ${cfg.dotsDirImpure}${
+      if cfg.dotsDir == null # "-relink=" method extracts the "/relPath" from elem 1 of the relPathRegex match
+      then elemAt (match relPathRegex (toString x.source.path)) 1 # toString on the original passthru.path to avoid copying to store and IFD
+      else removePrefix "${cfg.dotsDir}" "${x.source}"
+    } ${x.target}"))
     (concatStringsSep "\n")
   ];
 
   replaceFiles = pipe cfg.parseAttrs [
-    (filter (x: ! (cfg.dotsDir != null && hasPrefix "${cfg.dotsDir}" "${x.source}")))
+    (filter (x:
+      ! (
+        if cfg.dotsDir == null
+        then cfg.dotsDirImpure != "" && ((substring 43 8 "${x.source}") == "-relink=")
+        else cfg.dotsDir != null && hasPrefix "${cfg.dotsDir}" "${x.source}"
+      )))
     (map (x: "replace ${x.target}"))
     (concatStringsSep "\n")
   ];
+
+  relink = path:
+    if isList path # [./. "filename"] workarounds edge case of concatenating paths with illegal store path chracters such as ./. + "@filename!"
+    then let path' = "/${elemAt path 1}"; in pkgs.runCommand "relink=${baseNameOf path'}" {passthru = {path = (head path) + path';};} "cp -a ${head path}${path'} $out"
+    else pkgs.runCommand "relink=${baseNameOf path}" {passthru = {inherit path;};} "cp -a ${path} $out"; # relink ./pathToFile, name relink=... & embeds passthru.path
 in {
   imports = [
     (mkRenamedOptionModule ["impure" "linkFiles"] ["impure" "parseAttrs"])
   ];
+
+  options.relink = mkOption {
+    type = raw;
+    readOnly = true;
+    internal = true;
+    default = relink;
+  };
 
   options.impure = {
     enable = mkEnableOption "hjem impure planting script";
@@ -154,7 +179,7 @@ in {
       }
     ];
 
-    warnings = optional (cfg.dotsDir != null && symlinkFiles == "") "hjem-impure: detected zero files to symlink";
+    warnings = optional (cfg.dotsDirImpure != "" && symlinkFiles == "") "hjem-impure: detected zero files to symlink";
     packages = [planter];
 
     # When you system is `pure` $XDG_STATE_HOME/HJEM_IMPURE_ACTIVE will be 0


### PR DESCRIPTION
This addresses the existing implementation's caveats:
- `dotsDir` from string interpolation of `"${./.}"` becomes a store path of the entire dots tree as a single source (`/nix/store/<HASH>-source`). So any change within the source tree recreates a new store path of it with a different hash on every rebuild.
- Since all files to be relinked are tied under the shared `dotsDir` store path (`/nix/store/<HASH>-source`) in order to have the same prefix, any unrelated changes (like `README.md`) will cause Hjem to always 'rebuild' all files under the shared `dotsDir` store path even when there are no actual changes in the individual files.
- These unnecessary rebuilds tied to the shared `dotsDir` store path result in the loss of granularity in changed diffs (`nix-output-monitor` dependency graph) for individual files and loses flake's 'eval caching' on unchanged rebuilds if anything tracked by git changes.
- The UX is a bit more verbose compared to the more natural `.source = ./directRelPathToFile` on paths directly that had per-file granularity. It requires `dotsDir` to be set as the string interpolation of the config root path and string concatenation of the full relative path from `dotsDir` to the file in `.source = dotsDir + "/relPathToFileFromDotsDir"` which also tightly couples file reference on relocation refactors etc.

To avoid breaking backward compatibility with existing `dotsDir`, the new implementation will only be used by default if `dotsDir` is unset as it requires only `dotsDirImpure` (`/home/$USER/myDotsFolder`) to be set for it to be active. 
- The new relink approach requires wrapping `./directRelPathToFile` under a derivation with the name set to prefix "`relink=` `<...filename>`"  to mark that it should be relinked (`/nix/store/<HASH>-relink=...`). It embeds the original path (`./directRelPathToFile`) within `passthru.path` for later reference without triggering IFD in order to extract the full relative path from `dotsDirImpure` structure. This is needed because it would be lost on regular `./directRelPathToFile` store copy which also lacks a way to distinguish which files to relink (`/nix/store/<HASH>-...`). The approach removes the need to set `dotsDir` for the shared prefix and its `"${./...}"` caveats, which allows for per-file granularity with the following helper function used in `.source = relink ./directRelPathToFile` that is also provided by `config.hjem.users.${myUserName}.relink` as an option: 
    ```nix
    relink = path: pkgs.runCommand "relink=${baseNameOf path}" {passthru = {inherit path;};} "cp -a ${path} $out"; 
    ```  
- In `symlinkFiles`, it filters by `"-relink="` marker instead of `dotsDir` (`/nix/store/<HASH>-source`) prefix:
    ```nix
    (substring 43 8 "${x.source}") == "-relink=" # /nix/store/ (11) + <HASH> (32) = 43, "-relink=" (8)
    ```
- For `pathExists` checks during eval time, since that the `/nix/store/<HASH>-relink=...` store path derivation at build time may not be realised yet, `pathExists` on it directly would cause an IFD that would slow down eval and wouldn't work under `nix.settings.allow-import-from-derivation = false;`. So the trick around that is to use the original `passthru.path` for `pathExists` without IFD!
    ```nix
    # ensures that paths are valid. Throws an error if they aren't. "-relink=" method checks on the original passthru.path instead of its build store path to avoid IFD
    (filter (x: assertMsg (pathExists (if cfg.dotsDir == null then x.source.path else x.source)) "hjem-impure: the path ${x.source} DOES NOT EXIST"))
    ```
- For extracting the relPath, the following match (Regex) is used to work from both within store paths (flakes) or outside within `dotsDirImpure` directly (non-flakes) at `elemAt (match relPathRegex (toString x.source.path)) 1`: 
    ```nix
    relPathRegex = "(${escapeRegex (removeSuffix "/" cfg.dotsDirImpure)}|/nix/store/[^/]+)(/.+)"; # Regex matches [(dotsDirImpure or "/nix/store/<HASH>-...") "/relPath"]
    ```
Notes:
- relink must only take a path type such as  `./relPathToFile`,  `./. + "/relPathToFile"`,  `../../relPathToFile`,  `./${"relPathToFile"}`, `dots + "/fullRelPathToFile"` (only if `dots` was set to a `./path` and not within `"${./...}"`) to pass along the original path within passthru. It won't work with string interpolation on paths such as `"${./relPathToFile}"`, `"${./.}/relPathToFile"`, `"${./.}" + "/relPathToFile"`  since that would directly copy to the nix store as `/nix/store/<HASH>-<filename>` which loses its full relPath structure on where exactly to relink back. Using `toString` on paths such as `toString ./relPathToFile`, `(toString ./.) + "/relPathToFile"` also won't work as that loses string context that the path originally had needed for `cp -a ${path} $out`. There isn't really a use case for those anyways.
- There is an annoying edge case at the Nix language level if the filename contains an 'illegal store character' such as `./${"@filename!"}` (https://github.com/NixOS/nix/issues/15933) where it errors before relink is even called with `error: path '<hash>-output<filename>' is not a valid store path: name '<filename>' contains illegal character '<...>'`. `builtins.path` with an explicit name parameter cannot be done there as that directly copies to the nix store which loses its relPath structure without a way to pass along the original path like `passthru.path`. To account for this, I've made it so that the relink option also accepts a list in the form of `[./. "relPathToFile"]` (note: excludes `"/"` in between as it's more convenient for variables like `[./. filename]`) similar to `lib.path.append`:
    ```nix
    relink = path:
        if isList path # [./. "filename"] workarounds edge case of concatenating paths with illegal store path chracters such as ./. + "@filename!"
        then let path' = "/${elemAt path 1}"; in pkgs.runCommand "relink=${baseNameOf path'}" {passthru = {path = (head path) + path';};} "cp -a ${head path}${path'} $out"
        else pkgs.runCommand "relink=${baseNameOf path}" {passthru = {inherit path;};} "cp -a ${path} $out"; # relink ./pathToFile, name relink=... & embeds passthru.path
    ```
    
    
I've left the docs unchanged for now, it would just be mostly renaming `dots` to `relink` and only using direct `./relPathToFile`
```nix
{config, pkgs, ...}:
{
  hjem.users.${myUserName} = {
    impure = {
	  # enable hjem-impure
      enable = true;
	  # impure absolute path to dots folder
      dotsDirImpure = "/home/myuser/nixos/myDotsFolder";
    };

    xdg.config.files = let
	  # relink helper
      relink = config.hjem.users.${myUserName}.relink;
	  # or directly
      relink = path: pkgs.runCommand "relink=${baseNameOf path}" {passthru = {inherit path;};} "cp -a ${path} $out"; 
    in {
	  # it is a requirement to use `relink` for the relinking feature
      "hypr/hyprland.conf".source = relink ./hyprland/hyprland.conf;
      "hypr/hypridle.conf".source = relink  ./hyprland/hypridle.conf;
    };
  };
}
```
TLDR: To try out the new PR implementation, refer to ^:
- [1.] Refactor `dots + "/fullRelPathToFile"` -> `relink ./directRelPathToFile` (let `relink = config.hjem.users.${myUserName}.relink;` in ...). Ensure that it's only paths for relink (such as `./path`, `../../path`, `./${"filename"}`, `./. + "/filename"`), don't do string interpolation on paths (such as `"${./rePathToFile}"`, `"${./.}" + "/filename"`) and `toString` on paths.
- [2.] Switch to the new relink implementation by removing existing `dotsDir = ...` under `hjem.users.${myUserName}.impure`.
- [3.] Set `dotsDirImpure = "/home/myuser/nixos/myDotsFolder";` under `hjem.users.${myUserName}.impure` if not already configured.
- Alternatively, you can directly set `relink = path: pkgs.runCommand "relink=${baseNameOf path}" {passthru = {inherit path;};} "cp -a ${path} $out";` somewhere like `_module.args` but it won't work for illegal store characters in filenames. For that, you will have to use `relink [./. "@illegalFileName!"]` from `config.hjem.users.${myUserName}.relink;` or copy it from 'Notes:' above to workaround the edge case.
- It should work on both flakes and non-flakes!
- Quick way to use the PR is by replacing:
    ```nix
    hjem.extraModules = [inputs.hjem-impure.hjemModules.default];
    ``` 
    with
    ```nix
    hjem.extraModules = [
      (builtins.fetchurl {
        url = "https://raw.githubusercontent.com/Rend0e/hjem-impure/refs/heads/relink-rework/nix/module.nix";
        sha256 = "sha256:1k4vbbkx00xbqmlicvbprvq124dfyi7i1sgazgay79fsndr6x3qd";
      })
    ];
    ```